### PR TITLE
feat: add ability to specify multiple allowed origins for CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,6 @@ GOOGLE_ALLOWED_DOMAINS=localhost:3000  # Restrict to specific domains
 OAUTH_STATE_TIMEOUT=600                         # State timeout in seconds
 OAUTH_RATE_LIMIT_REQUESTS=5                     # Requests per minute
 GOOGLE_PROMPT_TYPE=select_account consent       # Force consent screen
+
+# Allowed Origins
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -131,9 +131,9 @@ func main() {
 	// Initialize router
 	r := gin.Default()
 
-	// Add CORS middleware with more permissive settings for development
+	// Add CORS middleware with configurable origins
 	corsConfig := cors.Config{
-		AllowOrigins:     []string{cfg.FrontendURL},
+		AllowOrigins:     cfg.AllowedOrigins,
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Content-Type", "Accept", "Authorization", "Cookie"},
 		ExposeHeaders:    []string{"Set-Cookie"},

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -171,11 +171,6 @@ func (h *AuthHandler) BeginGoogleAuth(c *gin.Context) {
 }
 
 func (h *AuthHandler) GoogleCallback(c *gin.Context) {
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		log.Fatalf("Failed to load config: %v", err)
-	}
-
 	provider, err := goth.GetProvider("google")
 	if err != nil {
 		log.Printf("Failed to get provider: %v", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 )
 
 type Config struct {
@@ -22,9 +23,9 @@ type Config struct {
 		GoogleClientID     string
 		GoogleClientSecret string
 	}
-	FrontendURL string
-	BackendURL  string
-	Redis       struct {
+	AllowedOrigins []string
+	BackendURL     string
+	Redis          struct {
 		Host     string
 		Port     string
 		Password string
@@ -50,8 +51,16 @@ func LoadConfig() (*Config, error) {
 	cfg.Redis.Port = getEnv("REDIS_PORT", "6379")
 	cfg.Redis.Password = getEnv("REDIS_PASSWORD", "")
 
-	// Frontend and Backend URLs
-	cfg.FrontendURL = getEnv("FRONTEND_URL", "http://localhost:3000")
+	// Load allowed origins from environment variable
+	// Format: comma-separated list of origins
+	allowedOriginsStr := getEnv("ALLOWED_ORIGINS", "http://localhost:3000")
+	cfg.AllowedOrigins = strings.Split(allowedOriginsStr, ",")
+
+	// Trim spaces from each origin
+	for i, origin := range cfg.AllowedOrigins {
+		cfg.AllowedOrigins[i] = strings.TrimSpace(origin)
+	}
+
 	cfg.BackendURL = getEnv("BACKEND_URL", "http://localhost:8080")
 
 	// OAuth config


### PR DESCRIPTION
add ability to specify multiple allowed origins for CORS policy, useful for our production and preview deployments

fixes #38