### PR TITLE
Store areas of interest on general applications

### DIFF
--- a/internal/handlers/general_application_handler.go
+++ b/internal/handlers/general_application_handler.go
@@ -42,6 +42,15 @@ var allowedApplicationAvailability = map[string]struct{}{
 	"8 hours or more": {},
 }
 
+var allowedApplicationInterests = map[string]struct{}{
+	"Startups & Venture Creation":      {},
+	"Venture Capital & Private Equity": {},
+	"AI Consulting & Implementation":   {},
+	"Healthcare & Biotech":             {},
+	"Consumer Tech & Retail":           {},
+	"Finance & Investment":             {},
+}
+
 var allowedApplicationGenders = map[string]struct{}{
 	"Female":            {},
 	"Male":              {},
@@ -85,6 +94,7 @@ type generalApplicationInput struct {
 	LinkedinURL          string
 	AdditionalLinks      []string
 	Teams                []string
+	Interests            []string
 	Availability         string
 	Contribution         string
 	DataRetentionConsent bool
@@ -175,6 +185,7 @@ func (h *GeneralApplicationHandler) Create(c *gin.Context) {
 			Teams:                 pq.StringArray(input.Teams),
 			TeamPreferencesRanked: true,
 			TeamInterestReason:    "",
+			Interests:             pq.StringArray(input.Interests),
 			Availability:          strings.TrimSpace(input.Availability),
 			Contribution:          strings.TrimSpace(input.Contribution),
 			DataRetentionConsent:  input.DataRetentionConsent,
@@ -395,6 +406,7 @@ func parseGeneralApplicationForm(c *gin.Context) (generalApplicationInput, error
 		LinkedinURL:          strings.TrimSpace(c.PostForm("linkedinUrl")),
 		AdditionalLinks:      normalizeLinks(c.PostFormArray("additionalLinks"), c.PostForm("additionalLinks")),
 		Teams:                normalizeRepeatedValues(c.PostFormArray("teams")),
+		Interests:            normalizeRepeatedValues(c.PostFormArray("interests")),
 		Availability:         strings.TrimSpace(c.PostForm("availability")),
 		Contribution:         strings.TrimSpace(c.PostForm("contribution")),
 		DataRetentionConsent: strings.EqualFold(strings.TrimSpace(c.PostForm("dataRetentionConsent")), "true"),
@@ -449,6 +461,22 @@ func validateGeneralApplicationInput(input generalApplicationInput) error {
 			return fmt.Errorf("each team can only be ranked once")
 		}
 		seenTeams[team] = struct{}{}
+	}
+	if len(input.Interests) == 0 {
+		return fmt.Errorf("choose at least one area of interest")
+	}
+	if len(input.Interests) > len(allowedApplicationInterests) {
+		return fmt.Errorf("choose at most %d areas of interest", len(allowedApplicationInterests))
+	}
+	seenInterests := make(map[string]struct{}, len(input.Interests))
+	for _, interest := range input.Interests {
+		if _, ok := allowedApplicationInterests[interest]; !ok {
+			return fmt.Errorf("invalid interest")
+		}
+		if _, ok := seenInterests[interest]; ok {
+			return fmt.Errorf("each interest can only be selected once")
+		}
+		seenInterests[interest] = struct{}{}
 	}
 	if _, ok := allowedApplicationAvailability[input.Availability]; !ok {
 		return fmt.Errorf("invalid availability")

--- a/internal/handlers/general_application_handler_test.go
+++ b/internal/handlers/general_application_handler_test.go
@@ -179,6 +179,21 @@ func TestValidateGeneralApplicationInput(t *testing.T) {
 			wantErr: "once",
 		},
 		{
+			name: "too many interests",
+			mutate: func(input *generalApplicationInput) {
+				input.Interests = []string{
+					"Startups & Venture Creation",
+					"Venture Capital & Private Equity",
+					"AI Consulting & Implementation",
+					"Healthcare & Biotech",
+					"Consumer Tech & Retail",
+					"Finance & Investment",
+					"Startups & Venture Creation",
+				}
+			},
+			wantErr: "at most 6 areas of interest",
+		},
+		{
 			name: "invalid availability",
 			mutate: func(input *generalApplicationInput) {
 				input.Availability = "1-3 hours"

--- a/internal/handlers/general_application_handler_test.go
+++ b/internal/handlers/general_application_handler_test.go
@@ -19,6 +19,7 @@ func validGeneralApplicationInput() generalApplicationInput {
 		LinkedinURL:          "https://www.linkedin.com/in/adalovelace",
 		AdditionalLinks:      []string{"https://github.com/ada"},
 		Teams:                []string{"Development", "Research", "Business", "Growth", "IT"},
+		Interests:            []string{"Startups & Venture Creation", "Finance & Investment"},
 		Availability:         "6-8 hours",
 		Contribution:         "I can contribute by building products, writing clearly, and helping organize technical work.",
 		DataRetentionConsent: true,
@@ -153,6 +154,27 @@ func TestValidateGeneralApplicationInput(t *testing.T) {
 			name: "duplicate team",
 			mutate: func(input *generalApplicationInput) {
 				input.Teams = []string{"Development", "Research", "Business", "Growth", "Growth"}
+			},
+			wantErr: "once",
+		},
+		{
+			name: "missing interests",
+			mutate: func(input *generalApplicationInput) {
+				input.Interests = nil
+			},
+			wantErr: "at least one area of interest",
+		},
+		{
+			name: "invalid interest",
+			mutate: func(input *generalApplicationInput) {
+				input.Interests = []string{"Crypto & Web3"}
+			},
+			wantErr: "invalid interest",
+		},
+		{
+			name: "duplicate interest",
+			mutate: func(input *generalApplicationInput) {
+				input.Interests = []string{"Finance & Investment", "Finance & Investment"}
 			},
 			wantErr: "once",
 		},

--- a/internal/models/general_application.go
+++ b/internal/models/general_application.go
@@ -38,7 +38,7 @@ type GeneralApplication struct {
 	Teams                 pq.StringArray           `gorm:"type:text[];not null" json:"teams"`
 	TeamPreferencesRanked bool                     `gorm:"not null;default:false" json:"team_preferences_ranked"`
 	TeamInterestReason    string                   `gorm:"type:text;not null" json:"team_interest_reason"`
-	Interests             pq.StringArray           `gorm:"type:text[];not null" json:"interests"`
+	Interests             pq.StringArray           `gorm:"type:text[];not null;default:'{}'" json:"interests"`
 	Availability          string                   `gorm:"not null" json:"availability"`
 	Contribution          string                   `gorm:"type:text;not null" json:"contribution"`
 	DataRetentionConsent  bool                     `gorm:"not null;default:false" json:"data_retention_consent"`

--- a/internal/models/general_application.go
+++ b/internal/models/general_application.go
@@ -38,6 +38,7 @@ type GeneralApplication struct {
 	Teams                 pq.StringArray           `gorm:"type:text[];not null" json:"teams"`
 	TeamPreferencesRanked bool                     `gorm:"not null;default:false" json:"team_preferences_ranked"`
 	TeamInterestReason    string                   `gorm:"type:text;not null" json:"team_interest_reason"`
+	Interests             pq.StringArray           `gorm:"type:text[];not null" json:"interests"`
 	Availability          string                   `gorm:"not null" json:"availability"`
 	Contribution          string                   `gorm:"type:text;not null" json:"contribution"`
 	DataRetentionConsent  bool                     `gorm:"not null;default:false" json:"data_retention_consent"`


### PR DESCRIPTION
Adds an Interests text[] column to GeneralApplication (auto-migrated on boot) alongside form parsing and validation mirroring the existing Teams field: 1-6 values from a fixed allow-list, no duplicates.