### PR TITLE
Expand newsletter signup to full applicant fields, add application op…

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -127,6 +127,7 @@ func main() {
 		&models.TeamProjectPair{},
 		&models.TeamMemberPair{},
 		&models.GeneralApplication{},
+		&models.NewsletterSubscription{},
 	)
 	if err != nil {
 		log.Fatal("Failed to migrate database:", err)
@@ -201,14 +202,14 @@ func setupRoutes(r *gin.Engine, db *gorm.DB, mailchimpApi *mailchimp.MailchimpAP
 	// Register all handlers
 	allHandlers := []handlers.Handler{
 		handlers.NewAuthHandler(db, mailchimpApi, cfg),
-		handlers.NewNewsletterHandler(mailchimpApi),
+		handlers.NewNewsletterHandler(db, mailchimpApi),
 		handlers.NewProfileHandler(db, mailchimpApi, cfg),
 		handlers.NewAdminHandler(db, cfg),
 		handlers.NewCompanyHandler(db, cfg),
 		handlers.NewJobListingHandler(db, cfg),
 		handlers.NewProjectHandler(db, cfg),
 		handlers.NewTeamHandler(db, cfg),
-		handlers.NewGeneralApplicationHandler(db, cfg),
+		handlers.NewGeneralApplicationHandler(db, cfg, mailchimpApi),
 	}
 
 	for _, h := range allHandlers {

--- a/internal/handlers/general_application_handler.go
+++ b/internal/handlers/general_application_handler.go
@@ -479,21 +479,8 @@ func validateGeneralApplicationInput(input generalApplicationInput) error {
 		}
 		seenTeams[team] = struct{}{}
 	}
-	if len(input.Interests) == 0 {
-		return fmt.Errorf("choose at least one area of interest")
-	}
-	if len(input.Interests) > len(allowedApplicationInterests) {
-		return fmt.Errorf("choose at most %d areas of interest", len(allowedApplicationInterests))
-	}
-	seenInterests := make(map[string]struct{}, len(input.Interests))
-	for _, interest := range input.Interests {
-		if _, ok := allowedApplicationInterests[interest]; !ok {
-			return fmt.Errorf("invalid interest")
-		}
-		if _, ok := seenInterests[interest]; ok {
-			return fmt.Errorf("each interest can only be selected once")
-		}
-		seenInterests[interest] = struct{}{}
+	if err := validation.ValidateInterests(input.Interests); err != nil {
+		return err
 	}
 	if _, ok := allowedApplicationAvailability[input.Availability]; !ok {
 		return fmt.Errorf("invalid availability")

--- a/internal/handlers/general_application_handler.go
+++ b/internal/handlers/general_application_handler.go
@@ -3,9 +3,11 @@ package handlers
 import (
 	"backend/internal/config"
 	"backend/internal/email"
+	"backend/internal/mailchimp"
 	"backend/internal/middleware"
 	"backend/internal/models"
 	"backend/internal/utils"
+	"backend/internal/validation"
 	"fmt"
 	"io"
 	"log"
@@ -42,22 +44,9 @@ var allowedApplicationAvailability = map[string]struct{}{
 	"8 hours or more": {},
 }
 
-var allowedApplicationInterests = map[string]struct{}{
-	"Startups & Venture Creation":      {},
-	"Venture Capital & Private Equity": {},
-	"AI Consulting & Implementation":   {},
-	"Healthcare & Biotech":             {},
-	"Consumer Tech & Retail":           {},
-	"Finance & Investment":             {},
-}
+var allowedApplicationInterests = validation.AllowedInterests
 
-var allowedApplicationGenders = map[string]struct{}{
-	"Female":            {},
-	"Male":              {},
-	"Non-binary":        {},
-	"Prefer not to say": {},
-	"Other":             {},
-}
+var allowedApplicationGenders = validation.AllowedGenders
 
 var allowedApplicationStatuses = map[models.GeneralApplicationStatus]struct{}{
 	models.GeneralApplicationStatusPending:  {},
@@ -79,8 +68,9 @@ var allowedResumeContentTypes = map[string]struct{}{
 }
 
 type GeneralApplicationHandler struct {
-	db  *gorm.DB
-	cfg *config.Config
+	db        *gorm.DB
+	cfg       *config.Config
+	mailchimp *mailchimp.MailchimpAPI
 }
 
 type generalApplicationInput struct {
@@ -98,10 +88,11 @@ type generalApplicationInput struct {
 	Availability         string
 	Contribution         string
 	DataRetentionConsent bool
+	NewsletterOptIn      bool
 }
 
-func NewGeneralApplicationHandler(db *gorm.DB, cfg *config.Config) *GeneralApplicationHandler {
-	return &GeneralApplicationHandler{db: db, cfg: cfg}
+func NewGeneralApplicationHandler(db *gorm.DB, cfg *config.Config, mailchimpApi *mailchimp.MailchimpAPI) *GeneralApplicationHandler {
+	return &GeneralApplicationHandler{db: db, cfg: cfg, mailchimp: mailchimpApi}
 }
 
 func (h *GeneralApplicationHandler) Register(r *gin.RouterGroup) {
@@ -220,6 +211,31 @@ func (h *GeneralApplicationHandler) Create(c *gin.Context) {
 			log.Printf("failed to send general application confirmation email for %s: %v", application.Id, err)
 		}
 	}(application)
+
+	if input.NewsletterOptIn {
+		go func(application models.GeneralApplication) {
+			subscription, err := upsertNewsletterSubscription(h.db, newsletterSubscriptionFields{
+				FirstName:            application.FirstName,
+				LastName:             application.LastName,
+				Email:                application.Email,
+				EmailNormalized:      application.EmailNormalized,
+				Gender:               application.Gender,
+				University:           application.University,
+				Programme:            application.Programme,
+				GraduationYear:       application.GraduationYear,
+				Interests:            application.Interests,
+				DataRetentionConsent: true,
+				Source:               models.NewsletterSourceApplicationOptIn,
+			})
+			if err != nil {
+				log.Printf("failed to store newsletter opt-in for application %s: %v", application.Id, err)
+				return
+			}
+			if err := h.mailchimp.SubscribeNewsletterSubscriber(subscription); err != nil {
+				log.Printf("newsletter opt-in: mailchimp sync failed for %s: %v", subscription.Email, err)
+			}
+		}(application)
+	}
 
 	c.JSON(http.StatusCreated, gin.H{
 		"id":         application.Id,
@@ -410,6 +426,7 @@ func parseGeneralApplicationForm(c *gin.Context) (generalApplicationInput, error
 		Availability:         strings.TrimSpace(c.PostForm("availability")),
 		Contribution:         strings.TrimSpace(c.PostForm("contribution")),
 		DataRetentionConsent: strings.EqualFold(strings.TrimSpace(c.PostForm("dataRetentionConsent")), "true"),
+		NewsletterOptIn:      strings.EqualFold(strings.TrimSpace(c.PostForm("newsletterOptIn")), "true"),
 	}, nil
 }
 

--- a/internal/handlers/newsletter_handler.go
+++ b/internal/handlers/newsletter_handler.go
@@ -3,18 +3,27 @@ package handlers
 import (
 	"backend/internal/mailchimp"
 	"backend/internal/middleware"
+	"backend/internal/models"
+	"backend/internal/validation"
+	"errors"
+	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"gorm.io/gorm"
 )
 
 type NewsletterHandler struct {
+	db        *gorm.DB
 	mailchimp *mailchimp.MailchimpAPI
 }
 
-func NewNewsletterHandler(mc *mailchimp.MailchimpAPI) *NewsletterHandler {
-	return &NewsletterHandler{mailchimp: mc}
+func NewNewsletterHandler(db *gorm.DB, mailchimpApi *mailchimp.MailchimpAPI) *NewsletterHandler {
+	return &NewsletterHandler{db: db, mailchimp: mailchimpApi}
 }
 
 func (h *NewsletterHandler) Register(r *gin.RouterGroup) {
@@ -23,7 +32,15 @@ func (h *NewsletterHandler) Register(r *gin.RouterGroup) {
 }
 
 type newsletterSubscribeBody struct {
-	Email string `json:"email" binding:"required,email"`
+	FirstName            string   `json:"firstName"`
+	LastName             string   `json:"lastName"`
+	Email                string   `json:"email"`
+	Gender               string   `json:"gender"`
+	University           string   `json:"university"`
+	Programme            string   `json:"programme"`
+	GraduationYear       int      `json:"graduationYear"`
+	Interests            []string `json:"interests"`
+	DataRetentionConsent bool     `json:"dataRetentionConsent"`
 }
 
 func (h *NewsletterHandler) Subscribe(c *gin.Context) {
@@ -32,10 +49,132 @@ func (h *NewsletterHandler) Subscribe(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
 		return
 	}
-	if err := h.mailchimp.SubscribeNewsletter(body.Email); err != nil {
-		log.Printf("newsletter subscribe: %v", err)
-		c.JSON(http.StatusBadGateway, gin.H{"error": "could not subscribe"})
+
+	if err := validateNewsletterSubscribeBody(body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+
+	subscription, err := upsertNewsletterSubscription(h.db, newsletterSubscriptionFields{
+		FirstName:            strings.TrimSpace(body.FirstName),
+		LastName:             strings.TrimSpace(body.LastName),
+		Email:                strings.TrimSpace(body.Email),
+		EmailNormalized:      normalizeEmail(body.Email),
+		Gender:               body.Gender,
+		University:           strings.TrimSpace(body.University),
+		Programme:            strings.TrimSpace(body.Programme),
+		GraduationYear:       body.GraduationYear,
+		Interests:            body.Interests,
+		DataRetentionConsent: body.DataRetentionConsent,
+		Source:               models.NewsletterSourceForm,
+	})
+	if err != nil {
+		log.Printf("newsletter subscribe: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "could not subscribe"})
+		return
+	}
+
+	if err := h.mailchimp.SubscribeNewsletterSubscriber(subscription); err != nil {
+		log.Printf("newsletter subscribe: mailchimp sync failed for %s: %v", subscription.Email, err)
+	}
+
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func validateNewsletterSubscribeBody(body newsletterSubscribeBody) error {
+	if len(strings.TrimSpace(body.FirstName)) == 0 || len(body.FirstName) > 80 {
+		return fmt.Errorf("first name is required and must be at most 80 characters")
+	}
+	if len(strings.TrimSpace(body.LastName)) == 0 || len(body.LastName) > 80 {
+		return fmt.Errorf("last name is required and must be at most 80 characters")
+	}
+	if !isValidEmail(body.Email) {
+		return fmt.Errorf("valid email is required")
+	}
+	if _, ok := validation.AllowedGenders[body.Gender]; !ok {
+		return fmt.Errorf("invalid gender")
+	}
+	if strings.TrimSpace(body.University) == "" {
+		return fmt.Errorf("university is required")
+	}
+	if strings.TrimSpace(body.Programme) == "" {
+		return fmt.Errorf("programme is required")
+	}
+	if body.GraduationYear < 2026 || body.GraduationYear > 2100 {
+		return fmt.Errorf("graduation year must be 2026 or later")
+	}
+	if len(body.Interests) == 0 {
+		return fmt.Errorf("choose at least one area of interest")
+	}
+	if len(body.Interests) > len(validation.AllowedInterests) {
+		return fmt.Errorf("choose at most %d areas of interest", len(validation.AllowedInterests))
+	}
+	seenInterests := make(map[string]struct{}, len(body.Interests))
+	for _, interest := range body.Interests {
+		if _, ok := validation.AllowedInterests[interest]; !ok {
+			return fmt.Errorf("invalid interest")
+		}
+		if _, ok := seenInterests[interest]; ok {
+			return fmt.Errorf("each interest can only be selected once")
+		}
+		seenInterests[interest] = struct{}{}
+	}
+	if !body.DataRetentionConsent {
+		return fmt.Errorf("data retention consent is required")
+	}
+	return nil
+}
+
+// newsletterSubscriptionFields is the shared shape used to create/update a
+// NewsletterSubscription from either the newsletter form itself or an
+// applicant opting in from the general application form.
+type newsletterSubscriptionFields struct {
+	FirstName            string
+	LastName             string
+	Email                string
+	EmailNormalized      string
+	Gender               string
+	University           string
+	Programme            string
+	GraduationYear       int
+	Interests            []string
+	DataRetentionConsent bool
+	Source               string
+}
+
+// upsertNewsletterSubscription creates or updates the subscriber record for
+// the given (normalized) email, so re-subscribing or opting in again from an
+// application just refreshes the stored fields instead of erroring.
+func upsertNewsletterSubscription(db *gorm.DB, input newsletterSubscriptionFields) (*models.NewsletterSubscription, error) {
+	var subscription models.NewsletterSubscription
+	isNew := false
+	if err := db.Where("email_normalized = ?", input.EmailNormalized).First(&subscription).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, err
+		}
+		isNew = true
+		subscription = models.NewsletterSubscription{Id: uuid.New()}
+	}
+
+	subscription.FirstName = input.FirstName
+	subscription.LastName = input.LastName
+	subscription.Email = input.Email
+	subscription.EmailNormalized = input.EmailNormalized
+	subscription.Gender = input.Gender
+	subscription.University = input.University
+	subscription.Programme = input.Programme
+	subscription.GraduationYear = input.GraduationYear
+	subscription.Interests = pq.StringArray(input.Interests)
+	subscription.DataRetentionConsent = input.DataRetentionConsent
+	subscription.Source = input.Source
+
+	if isNew {
+		if err := db.Create(&subscription).Error; err != nil {
+			return nil, err
+		}
+	} else if err := db.Save(&subscription).Error; err != nil {
+		return nil, err
+	}
+
+	return &subscription, nil
 }

--- a/internal/handlers/newsletter_handler.go
+++ b/internal/handlers/newsletter_handler.go
@@ -5,7 +5,6 @@ import (
 	"backend/internal/middleware"
 	"backend/internal/models"
 	"backend/internal/validation"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -15,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type NewsletterHandler struct {
@@ -82,10 +82,12 @@ func (h *NewsletterHandler) Subscribe(c *gin.Context) {
 }
 
 func validateNewsletterSubscribeBody(body newsletterSubscribeBody) error {
-	if len(strings.TrimSpace(body.FirstName)) == 0 || len(body.FirstName) > 80 {
+	firstName := strings.TrimSpace(body.FirstName)
+	if len(firstName) == 0 || len(firstName) > 80 {
 		return fmt.Errorf("first name is required and must be at most 80 characters")
 	}
-	if len(strings.TrimSpace(body.LastName)) == 0 || len(body.LastName) > 80 {
+	lastName := strings.TrimSpace(body.LastName)
+	if len(lastName) == 0 || len(lastName) > 80 {
 		return fmt.Errorf("last name is required and must be at most 80 characters")
 	}
 	if !isValidEmail(body.Email) {
@@ -145,36 +147,48 @@ type newsletterSubscriptionFields struct {
 // upsertNewsletterSubscription creates or updates the subscriber record for
 // the given (normalized) email, so re-subscribing or opting in again from an
 // application just refreshes the stored fields instead of erroring.
+//
+// This is done as a single atomic INSERT ... ON CONFLICT rather than a
+// SELECT followed by CREATE/UPDATE: two concurrent submissions for the same
+// email would otherwise both see "not found" and race to CREATE, and the
+// loser would hit the email_normalized unique constraint and return a 500
+// (skipping the Mailchimp sync) even though the subscription was already
+// stored. Source is intentionally left out of the update so a later
+// re-subscribe/opt-in doesn't overwrite how someone first signed up.
 func upsertNewsletterSubscription(db *gorm.DB, input newsletterSubscriptionFields) (*models.NewsletterSubscription, error) {
-	var subscription models.NewsletterSubscription
-	isNew := false
-	if err := db.Where("email_normalized = ?", input.EmailNormalized).First(&subscription).Error; err != nil {
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, err
-		}
-		isNew = true
-		subscription = models.NewsletterSubscription{Id: uuid.New()}
+	subscription := models.NewsletterSubscription{
+		Id:                   uuid.New(),
+		FirstName:            input.FirstName,
+		LastName:             input.LastName,
+		Email:                input.Email,
+		EmailNormalized:      input.EmailNormalized,
+		Gender:               input.Gender,
+		University:           input.University,
+		Programme:            input.Programme,
+		GraduationYear:       input.GraduationYear,
+		Interests:            pq.StringArray(input.Interests),
+		DataRetentionConsent: input.DataRetentionConsent,
+		Source:               input.Source,
 	}
 
-	subscription.FirstName = input.FirstName
-	subscription.LastName = input.LastName
-	subscription.Email = input.Email
-	subscription.EmailNormalized = input.EmailNormalized
-	subscription.Gender = input.Gender
-	subscription.University = input.University
-	subscription.Programme = input.Programme
-	subscription.GraduationYear = input.GraduationYear
-	subscription.Interests = pq.StringArray(input.Interests)
-	subscription.DataRetentionConsent = input.DataRetentionConsent
-	subscription.Source = input.Source
-
-	if isNew {
-		if err := db.Create(&subscription).Error; err != nil {
-			return nil, err
-		}
-	} else if err := db.Save(&subscription).Error; err != nil {
+	err := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "email_normalized"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"first_name", "last_name", "email", "gender", "university",
+			"programme", "graduation_year", "interests", "data_retention_consent",
+		}),
+	}).Create(&subscription).Error
+	if err != nil {
 		return nil, err
 	}
 
-	return &subscription, nil
+	// Re-read rather than trust the in-memory struct: on the conflict path
+	// the DB keeps the original row's Id/CreatedAt, which the local struct
+	// above (built with a fresh Id) does not reflect.
+	var stored models.NewsletterSubscription
+	if err := db.Where("email_normalized = ?", input.EmailNormalized).First(&stored).Error; err != nil {
+		return nil, err
+	}
+
+	return &stored, nil
 }

--- a/internal/handlers/newsletter_handler.go
+++ b/internal/handlers/newsletter_handler.go
@@ -105,21 +105,8 @@ func validateNewsletterSubscribeBody(body newsletterSubscribeBody) error {
 	if body.GraduationYear < 2026 || body.GraduationYear > 2100 {
 		return fmt.Errorf("graduation year must be 2026 or later")
 	}
-	if len(body.Interests) == 0 {
-		return fmt.Errorf("choose at least one area of interest")
-	}
-	if len(body.Interests) > len(validation.AllowedInterests) {
-		return fmt.Errorf("choose at most %d areas of interest", len(validation.AllowedInterests))
-	}
-	seenInterests := make(map[string]struct{}, len(body.Interests))
-	for _, interest := range body.Interests {
-		if _, ok := validation.AllowedInterests[interest]; !ok {
-			return fmt.Errorf("invalid interest")
-		}
-		if _, ok := seenInterests[interest]; ok {
-			return fmt.Errorf("each interest can only be selected once")
-		}
-		seenInterests[interest] = struct{}{}
+	if err := validation.ValidateInterests(body.Interests); err != nil {
+		return err
 	}
 	if !body.DataRetentionConsent {
 		return fmt.Errorf("data retention consent is required")

--- a/internal/handlers/newsletter_handler.go
+++ b/internal/handlers/newsletter_handler.go
@@ -176,6 +176,7 @@ func upsertNewsletterSubscription(db *gorm.DB, input newsletterSubscriptionField
 		DoUpdates: clause.AssignmentColumns([]string{
 			"first_name", "last_name", "email", "gender", "university",
 			"programme", "graduation_year", "interests", "data_retention_consent",
+			"updated_at",
 		}),
 	}).Create(&subscription).Error
 	if err != nil {

--- a/internal/handlers/newsletter_handler_test.go
+++ b/internal/handlers/newsletter_handler_test.go
@@ -1,0 +1,129 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func validNewsletterSubscribeBody() newsletterSubscribeBody {
+	return newsletterSubscribeBody{
+		FirstName:            "Ada",
+		LastName:             "Lovelace",
+		Email:                "ada@example.com",
+		Gender:               "Female",
+		University:           "KTH Royal Institute of Technology",
+		Programme:            "Computer Science",
+		GraduationYear:       2027,
+		Interests:            []string{"Startups & Venture Creation", "Finance & Investment"},
+		DataRetentionConsent: true,
+	}
+}
+
+func TestValidateNewsletterSubscribeBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*newsletterSubscribeBody)
+		wantErr string
+	}{
+		{
+			name: "valid input",
+		},
+		{
+			name: "missing first name",
+			mutate: func(body *newsletterSubscribeBody) {
+				body.FirstName = ""
+			},
+			wantErr: "first name",
+		},
+		{
+			name: "missing last name",
+			mutate: func(body *newsletterSubscribeBody) {
+				body.LastName = ""
+			},
+			wantErr: "last name",
+		},
+		{
+			name: "invalid email",
+			mutate: func(body *newsletterSubscribeBody) {
+				body.Email = "not-an-email"
+			},
+			wantErr: "email",
+		},
+		{
+			name: "invalid gender",
+			mutate: func(body *newsletterSubscribeBody) {
+				body.Gender = ""
+			},
+			wantErr: "gender",
+		},
+		{
+			name: "missing university",
+			mutate: func(body *newsletterSubscribeBody) {
+				body.University = ""
+			},
+			wantErr: "university",
+		},
+		{
+			name: "missing programme",
+			mutate: func(body *newsletterSubscribeBody) {
+				body.Programme = ""
+			},
+			wantErr: "programme",
+		},
+		{
+			name: "invalid graduation year too early",
+			mutate: func(body *newsletterSubscribeBody) {
+				body.GraduationYear = 2025
+			},
+			wantErr: "graduation year",
+		},
+		{
+			name: "missing interests",
+			mutate: func(body *newsletterSubscribeBody) {
+				body.Interests = nil
+			},
+			wantErr: "at least one area of interest",
+		},
+		{
+			name: "invalid interest",
+			mutate: func(body *newsletterSubscribeBody) {
+				body.Interests = []string{"Crypto & Web3"}
+			},
+			wantErr: "invalid interest",
+		},
+		{
+			name: "duplicate interest",
+			mutate: func(body *newsletterSubscribeBody) {
+				body.Interests = []string{"Finance & Investment", "Finance & Investment"}
+			},
+			wantErr: "once",
+		},
+		{
+			name: "missing data retention consent",
+			mutate: func(body *newsletterSubscribeBody) {
+				body.DataRetentionConsent = false
+			},
+			wantErr: "consent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := validNewsletterSubscribeBody()
+			if tt.mutate != nil {
+				tt.mutate(&body)
+			}
+
+			err := validateNewsletterSubscribeBody(body)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateNewsletterSubscribeBody() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateNewsletterSubscribeBody() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/mailchimp/member.go
+++ b/internal/mailchimp/member.go
@@ -148,6 +148,39 @@ func (api *MailchimpAPI) SubscribeMember(profile *models.Profile) error {
 	return nil
 }
 
+// SubscribeNewsletterSubscriber adds a newsletter subscriber with the merge
+// fields Mailchimp already supports (mirrors SubscribeMember, sourced from a
+// NewsletterSubscription instead of a Profile). Existing members are left
+// unchanged.
+func (api *MailchimpAPI) SubscribeNewsletterSubscriber(sub *models.NewsletterSubscription) error {
+	if !api.IsConfigured() {
+		return nil
+	}
+
+	_, memberResErr := api.GetMember(&sub.Email)
+	if memberResErr != nil {
+		serr, ok := memberResErr.(*MailchimpAPIError)
+		if ok && serr.Status == http.StatusNotFound {
+			req := &MemberRequest{
+				Email:  sub.Email,
+				Status: Subscribed,
+				MergeFields: MergeFields{
+					FirstName:      sub.FirstName,
+					LastName:       sub.LastName,
+					Programme:      sub.Programme,
+					GraduationYear: sub.GraduationYear,
+				},
+			}
+
+			_, addErr := api.AddMember(req)
+			return addErr
+		}
+		return memberResErr
+	}
+
+	return nil
+}
+
 // SubscribeNewsletter adds an email-only signup (e.g. landing page form). Existing members are left unchanged.
 func (api *MailchimpAPI) SubscribeNewsletter(email string) error {
 	if !api.IsConfigured() {

--- a/internal/models/newsletter_subscription.go
+++ b/internal/models/newsletter_subscription.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+)
+
+const (
+	NewsletterSourceForm             = "newsletter_form"
+	NewsletterSourceApplicationOptIn = "application_opt_in"
+)
+
+type NewsletterSubscription struct {
+	gorm.Model
+	Id                   uuid.UUID      `gorm:"uniqueIndex" json:"id"`
+	FirstName            string         `gorm:"not null" json:"first_name"`
+	LastName             string         `gorm:"not null" json:"last_name"`
+	Email                string         `gorm:"not null" json:"email"`
+	EmailNormalized      string         `gorm:"not null;uniqueIndex" json:"-"`
+	Gender               string         `gorm:"not null;default:'Prefer not to say'" json:"gender"`
+	University           string         `gorm:"not null;default:''" json:"university"`
+	Programme            string         `gorm:"not null;default:''" json:"programme"`
+	GraduationYear       int            `gorm:"not null;default:0" json:"graduation_year"`
+	Interests            pq.StringArray `gorm:"type:text[];not null;default:'{}'" json:"interests"`
+	DataRetentionConsent bool           `gorm:"not null;default:false" json:"data_retention_consent"`
+	Source               string         `gorm:"not null;default:'newsletter_form'" json:"source"`
+	CreatedAt            time.Time      `json:"created_at"`
+	UpdatedAt            time.Time      `json:"updated_at"`
+}

--- a/internal/validation/applicant_fields.go
+++ b/internal/validation/applicant_fields.go
@@ -1,0 +1,21 @@
+// Package validation holds allow-lists shared by any handler that collects
+// applicant-style fields (general applications, newsletter signups), so the
+// two flows can't drift out of sync with each other.
+package validation
+
+var AllowedGenders = map[string]struct{}{
+	"Female":            {},
+	"Male":              {},
+	"Non-binary":        {},
+	"Prefer not to say": {},
+	"Other":             {},
+}
+
+var AllowedInterests = map[string]struct{}{
+	"Startups & Venture Creation":      {},
+	"Venture Capital & Private Equity": {},
+	"AI Consulting & Implementation":   {},
+	"Healthcare & Biotech":             {},
+	"Consumer Tech & Retail":           {},
+	"Finance & Investment":             {},
+}

--- a/internal/validation/applicant_fields.go
+++ b/internal/validation/applicant_fields.go
@@ -3,6 +3,8 @@
 // two flows can't drift out of sync with each other.
 package validation
 
+import "fmt"
+
 var AllowedGenders = map[string]struct{}{
 	"Female":            {},
 	"Male":              {},
@@ -18,4 +20,27 @@ var AllowedInterests = map[string]struct{}{
 	"Healthcare & Biotech":             {},
 	"Consumer Tech & Retail":           {},
 	"Finance & Investment":             {},
+}
+
+// ValidateInterests checks that interests is a non-empty, duplicate-free
+// subset of AllowedInterests. Shared by the general application and
+// newsletter signup flows so their validation can't drift apart.
+func ValidateInterests(interests []string) error {
+	if len(interests) == 0 {
+		return fmt.Errorf("choose at least one area of interest")
+	}
+	if len(interests) > len(AllowedInterests) {
+		return fmt.Errorf("choose at most %d areas of interest", len(AllowedInterests))
+	}
+	seen := make(map[string]struct{}, len(interests))
+	for _, interest := range interests {
+		if _, ok := AllowedInterests[interest]; !ok {
+			return fmt.Errorf("invalid interest")
+		}
+		if _, ok := seen[interest]; ok {
+			return fmt.Errorf("each interest can only be selected once")
+		}
+		seen[interest] = struct{}{}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- Newsletter signups previously had no database record and only captured an email via Mailchimp. Adds a `NewsletterSubscription` table storing name, gender, university, programme, graduation year, interests, and consent — matching the general application's field set.
- Adds an optional `newsletterOptIn` field to the general application form; when set, it upserts a `NewsletterSubscription` from the applicant's own already-validated data and syncs it to Mailchimp, without asking for anything twice.
- **Review fix**: the upsert originally did a SELECT then a separate CREATE/UPDATE, so concurrent submissions for the same email could return a false 500 (and skip the Mailchimp sync) even though the row was saved. Replaced with a single atomic `INSERT ... ON CONFLICT`, with `source` excluded from the update so a later re-subscribe/opt-in can't overwrite how someone first signed up.
- **Review fix**: `updated_at` wasn't advancing on that same upsert path because the `ON CONFLICT DO UPDATE` column list omitted it.
- **Review fix**: first/last name length validation mixed trimmed and untrimmed checks; now consistently validates the trimmed value.
- **Cleanup**: extracted the interest-list validation (non-empty, no duplicates, in allow-list) shared by the general application and newsletter handlers into `internal/validation`, so the two flows can't drift apart.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/handlers/... ./internal/mailchimp/... ./internal/validation/...`
- [x] Verified locally end-to-end: newsletter signup and application opt-in both create/update rows correctly in `newsletter_subscriptions`
- [x] Verified concurrent submissions for the same email no longer 500 (fired 3 concurrent requests, all 200, single row created)
- [x] Verified `updated_at` correctly advances on re-subscribe/opt-in while `created_at` and `source` are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)