### PR TITLE
Order job listings newest first

### DIFF
--- a/api_docs/job_listing_handler.md
+++ b/api_docs/job_listing_handler.md
@@ -65,6 +65,7 @@ It registers routes under `/joblistings`, with several admin-only endpoints prot
   - `200 OK` with a JSON array of `SmallJobListing` objects.
 - Behavior:
   - Joins `job_listings` with `companies` to include company name.
+  - Orders listings from newest to oldest by creation time, with ID as a deterministic tie-breaker.
   - Returns fields: `id`, `title`, `company`, `salary`.
 
 ### `GET /joblistings/job`

--- a/internal/handlers/job_listing_handler.go
+++ b/internal/handlers/job_listing_handler.go
@@ -122,7 +122,12 @@ func (h *JobListingHandler) GetJobListing(c *gin.Context) {
 // Get with Query Params
 func (h *JobListingHandler) GetAllListings(c *gin.Context) {
 	var shortListings []SmallJobListing
-	h.db.Table("job_listings").Select(
+	jobListingSummaryQuery(h.db).Scan(&shortListings)
+	c.JSON(http.StatusOK, shortListings)
+}
+
+func jobListingSummaryQuery(db *gorm.DB) *gorm.DB {
+	return db.Table("job_listings").Select(
 		"job_listings.id",
 		"job_listings.name",
 		"job_listings.salary",
@@ -130,8 +135,8 @@ func (h *JobListingHandler) GetAllListings(c *gin.Context) {
 		"job_listings.location",
 		"companies.name as company",
 		"job_listings.company_id",
-	).Joins("left join companies on companies.id = job_listings.company_id").Scan(&shortListings)
-	c.JSON(http.StatusOK, shortListings)
+	).Joins("left join companies on companies.id = job_listings.company_id").
+		Order("job_listings.created_at DESC, job_listings.id DESC")
 }
 
 func (h *JobListingHandler) DeleteJobListing(c *gin.Context) {

--- a/internal/handlers/job_listing_handler.go
+++ b/internal/handlers/job_listing_handler.go
@@ -122,7 +122,10 @@ func (h *JobListingHandler) GetJobListing(c *gin.Context) {
 // Get with Query Params
 func (h *JobListingHandler) GetAllListings(c *gin.Context) {
 	var shortListings []SmallJobListing
-	jobListingSummaryQuery(h.db).Scan(&shortListings)
+	if err := jobListingSummaryQuery(h.db).Scan(&shortListings).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(http.StatusOK, shortListings)
 }
 

--- a/internal/handlers/job_listing_handler_test.go
+++ b/internal/handlers/job_listing_handler_test.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestJobListingSummaryQueryOrdersNewestFirst(t *testing.T) {
+	db, err := gorm.Open(postgres.Open("host=localhost user=test dbname=test sslmode=disable"), &gorm.Config{
+		DisableAutomaticPing: true,
+		DryRun:               true,
+	})
+	if err != nil {
+		t.Fatalf("open dry-run database: %v", err)
+	}
+
+	query := jobListingSummaryQuery(db).Scan(&[]SmallJobListing{})
+	sql := strings.Join(strings.Fields(query.Statement.SQL.String()), " ")
+	want := "ORDER BY job_listings.created_at DESC, job_listings.id DESC"
+	if !strings.Contains(sql, want) {
+		t.Fatalf("query ordering = %q, want it to contain %q", sql, want)
+	}
+}


### PR DESCRIPTION
## What changed

- order `GET /joblistings/all` results by creation time descending
- use job ID as a deterministic tie-breaker
- add focused query-ordering coverage and document the response order

## Why

The endpoint did not specify an `ORDER BY`, so consumers received database-dependent ordering. The frontend uses the first results for the homepage preview, which caused older job posts to appear before newer ones.

## Impact

The jobs page and homepage preview now receive newest-first listings without requiring frontend-specific reversal logic. The response schema is unchanged.

## Validation

- `go test ./...`
- `git diff --check`
