### PR TITLE
Update areas-of-interest options to AI/tech-focused categories

### DIFF
--- a/internal/handlers/general_application_handler_test.go
+++ b/internal/handlers/general_application_handler_test.go
@@ -19,7 +19,7 @@ func validGeneralApplicationInput() generalApplicationInput {
 		LinkedinURL:          "https://www.linkedin.com/in/adalovelace",
 		AdditionalLinks:      []string{"https://github.com/ada"},
 		Teams:                []string{"Development", "Research", "Business", "Growth", "IT"},
-		Interests:            []string{"Startups & Venture Creation", "Finance & Investment"},
+		Interests:            []string{"Startups & Venture Creation", "Machine Learning"},
 		Availability:         "6-8 hours",
 		Contribution:         "I can contribute by building products, writing clearly, and helping organize technical work.",
 		DataRetentionConsent: true,
@@ -174,7 +174,7 @@ func TestValidateGeneralApplicationInput(t *testing.T) {
 		{
 			name: "duplicate interest",
 			mutate: func(input *generalApplicationInput) {
-				input.Interests = []string{"Finance & Investment", "Finance & Investment"}
+				input.Interests = []string{"Machine Learning", "Machine Learning"}
 			},
 			wantErr: "once",
 		},
@@ -182,16 +182,22 @@ func TestValidateGeneralApplicationInput(t *testing.T) {
 			name: "too many interests",
 			mutate: func(input *generalApplicationInput) {
 				input.Interests = []string{
-					"Startups & Venture Creation",
+					"Machine Learning",
+					"Robotics & Autonomous Systems",
+					"Computer Vision & Graphics",
+					"Natural Language Processing",
+					"Data Science & Big Data Infrastructure",
+					"Embedded Systems & Edge AI",
+					"Cybersecurity & AI Safety Engineering",
+					"AI Research & Theoretical ML",
+					"Bioinformatics & Computational Biology",
+					"Quantitative Finance & Investment",
 					"Venture Capital & Private Equity",
-					"AI Consulting & Implementation",
-					"Healthcare & Biotech",
-					"Consumer Tech & Retail",
-					"Finance & Investment",
 					"Startups & Venture Creation",
+					"Machine Learning",
 				}
 			},
-			wantErr: "at most 6 areas of interest",
+			wantErr: "at most 12 areas of interest",
 		},
 		{
 			name: "invalid availability",

--- a/internal/handlers/newsletter_handler_test.go
+++ b/internal/handlers/newsletter_handler_test.go
@@ -14,7 +14,7 @@ func validNewsletterSubscribeBody() newsletterSubscribeBody {
 		University:           "KTH Royal Institute of Technology",
 		Programme:            "Computer Science",
 		GraduationYear:       2027,
-		Interests:            []string{"Startups & Venture Creation", "Finance & Investment"},
+		Interests:            []string{"Startups & Venture Creation", "Machine Learning"},
 		DataRetentionConsent: true,
 	}
 }
@@ -94,7 +94,7 @@ func TestValidateNewsletterSubscribeBody(t *testing.T) {
 		{
 			name: "duplicate interest",
 			mutate: func(body *newsletterSubscribeBody) {
-				body.Interests = []string{"Finance & Investment", "Finance & Investment"}
+				body.Interests = []string{"Machine Learning", "Machine Learning"}
 			},
 			wantErr: "once",
 		},

--- a/internal/validation/applicant_fields.go
+++ b/internal/validation/applicant_fields.go
@@ -14,12 +14,18 @@ var AllowedGenders = map[string]struct{}{
 }
 
 var AllowedInterests = map[string]struct{}{
-	"Startups & Venture Creation":      {},
-	"Venture Capital & Private Equity": {},
-	"AI Consulting & Implementation":   {},
-	"Healthcare & Biotech":             {},
-	"Consumer Tech & Retail":           {},
-	"Finance & Investment":             {},
+	"Machine Learning":                       {},
+	"Robotics & Autonomous Systems":          {},
+	"Computer Vision & Graphics":             {},
+	"Natural Language Processing":            {},
+	"Data Science & Big Data Infrastructure": {},
+	"Embedded Systems & Edge AI":             {},
+	"Cybersecurity & AI Safety Engineering":  {},
+	"AI Research & Theoretical ML":           {},
+	"Bioinformatics & Computational Biology": {},
+	"Quantitative Finance & Investment":      {},
+	"Venture Capital & Private Equity":       {},
+	"Startups & Venture Creation":            {},
 }
 
 // ValidateInterests checks that interests is a non-empty, duplicate-free


### PR DESCRIPTION
## Summary
Replaces the previous 6-item areas-of-interest list with 12 more specific technical and research categories:

**Before:** Startups & Venture Creation, Venture Capital & Private Equity, AI Consulting & Implementation, Healthcare & Biotech, Consumer Tech & Retail, Finance & Investment

**After:** Machine Learning, Robotics & Autonomous Systems, Computer Vision & Graphics, Natural Language Processing, Data Science & Big Data Infrastructure, Embedded Systems & Edge AI, Cybersecurity & AI Safety Engineering, AI Research & Theoretical ML, Bioinformatics & Computational Biology, Quantitative Finance & Investment, Venture Capital & Private Equity, Startups & Venture Creation

Only `validation.AllowedInterests` changes — both the general application and newsletter signup flows read from it via `validation.ValidateInterests`, so no handler logic changes. Existing stored applications/subscriptions keep their historical interest values (interests are a free-text array column, not a DB-level enum), only future submissions are validated against the new list.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/handlers/...` (updated fixtures/expectations for the new list and its new max-count of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)